### PR TITLE
Add react scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-router": "^4.2.0",
     "react-router-dom": "^4.3.1",
     "react-scripts": "1.1.4",
+    "react-scroll": "^1.7.9",
     "react-typist": "^2.0.4",
     "redux": "^4.0.0"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import MapPage from "./components/MapPage";
 import IntroPage from "./components/IntroPage";
 import reviewlist from "./reviewList";
 import { connect } from "react-redux";
-
+import { animateScroll as scroll } from "react-scroll";
 import {
 	addSearchResult,
 	setSearchLocation,
@@ -33,6 +33,7 @@ class App extends Component {
 		if (this.props.searchLocation) {
 			if (this.props.location.pathname === "/") {
 				this.props.history.push("/search");
+				scroll.scrollTo(330);
 			}
 			this.getLatLng();
 		}

--- a/src/components/MapPage.js
+++ b/src/components/MapPage.js
@@ -12,6 +12,7 @@ import {
 	setCenterLatLng,
 	clearSearchResults
 } from "../actions/actions";
+import { Element, scroller } from "react-scroll";
 
 class MapPage extends Component {
 	constructor(props) {
@@ -31,10 +32,14 @@ class MapPage extends Component {
 	}
 
 	handlePlaceClick(place) {
-		let lat = place.geometry.location.lat() + .035;
+		let lat = place.geometry.location.lat() + 0.035;
 		let lng = place.geometry.location.lng();
 		this.props.dispatch(setSelectedMarker(place.place_id));
 		this.props.dispatch(setCenterLatLng(lat, lng));
+		scroller.scrollTo("map-scroll", {
+			duration: 500,
+			smooth: true
+		});
 	}
 
 	clearPlaces() {
@@ -51,6 +56,7 @@ class MapPage extends Component {
 					handleListFilterChange={this.handleListFilterChange}
 					handlePlaceClick={this.handlePlaceClick}
 				/>
+				<Element name="map-scroll" />
 				<Map
 					{...this.props}
 					onGoogleApiLoaded={this.props.onGoogleApiLoaded}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7315,6 +7315,13 @@ react-scripts@1.1.4:
   optionalDependencies:
     fsevents "^1.1.3"
 
+react-scroll@^1.7.9:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.7.9.tgz#83e6bfc1e10a7b7ff7dbc34008b76737501aba6b"
+  dependencies:
+    lodash.throttle "^4.1.1"
+    prop-types "^15.5.8"
+
 react-scrollbar-size@^2.0.2:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/react-scrollbar-size/-/react-scrollbar-size-2.1.0.tgz#105e797135cab92b1f9e16f00071db7f29f80754"


### PR DESCRIPTION
Added react-scroll to improve user experience, especially on mobile devices. Now when places are selected on the list, the window will scroll to show the map, as well as the review, saving the user an annoying scroll to see the information. 